### PR TITLE
Added support for Super High Material CDs.

### DIFF
--- a/whatapi.py
+++ b/whatapi.py
@@ -78,6 +78,7 @@ def album_media(album):
         "HDCD": "CD",
         "DualDisc": "CD",
         "Copy Control CD": "CD",
+        "SHM-CD": "CD",
         "Vinyl": "Vinyl",
         "12\" Vinyl": "Vinyl",
         "Digital Media": "WEB",


### PR DESCRIPTION
Here is a list of all their release formats:
https://musicbrainz.org/doc/Release/Format

Cheers!

Did a simple test with 1 album that threw an error and with that extra line no longer does.